### PR TITLE
Add ability get the base structure of a valid metadata item from `datalad-catalog`

### DIFF
--- a/code/inject_metadata.py
+++ b/code/inject_metadata.py
@@ -13,15 +13,9 @@ import subprocess
 import tomli
 
 from datalad.api import Dataset, catalog_add
-
-
-def get_gitconfig(conf_name):
-    result = (
-        subprocess.run(["git", "config", conf_name], capture_output=True)
-        .stdout.decode()
-        .rstrip()
-    )
-    return result
+from datalad_catalog.schema_utils import (
+    get_metadata_item,
+)
 
 
 def get_ds_info(ds_path):
@@ -29,33 +23,16 @@ def get_ds_info(ds_path):
     return (ds.id, ds.repo.get_hexsha())
 
 
-def get_metadata_source():
-    """Create metadata_sources dict required by catalog schema"""
-    source = {
-        "key_source_map": {},
-        "sources": [
-            {
-                "source_name": "manual_addition",
-                "source_version": "0.1.0",
-                "source_time": datetime.now().timestamp(),
-                "agent_email": get_gitconfig("user.name"),
-                "agent_name": get_gitconfig("user.email"),
-            }
-        ],
-    }
-    return source
-
-
 def new_meta_item(ds_path):
     """Create a minimal valid dataset metadata blob in catalog schema"""
     ds = Dataset(ds_path)
-    meta_item = {
-        "type": "dataset",
-        "dataset_id": ds.id,
-        "dataset_version": ds.repo.get_hexsha(),
-        "name": "",
-        "metadata_sources": get_metadata_source(),
-    }
+    meta_item = get_metadata_item(
+        item_type='dataset',
+        dataset_id=ds.id,
+        dataset_version=ds.repo.get_hexsha(),
+        source_name="manual_addition",
+        source_version="0.1.0",
+    )
     return meta_item
 
 

--- a/code/list_files.py
+++ b/code/list_files.py
@@ -3,6 +3,9 @@ import json
 from pathlib import Path, PurePath
 
 from datalad_next.datasets import Dataset
+from datalad_catalog.schema_utils import (
+    get_metadata_item,
+)
 
 
 def transform_result(res):
@@ -31,10 +34,15 @@ args = parser.parse_args()
 
 
 ds = Dataset(args.dataset)
-file_required_meta = {
-    "dataset_id": ds.id,
-    "dataset_version": ds.repo.get_hexsha(),
-}
+
+file_required_meta = get_metadata_item(
+    item_type='file',
+    dataset_id=ds.id,
+    dataset_version=ds.repo.get_hexsha(),
+    source_name="manual_addition",
+    source_version="0.1.0",
+    exclude_keys=["path"],
+)
 
 results = ds.status(
     annex="basic",

--- a/docs/schema/jsonschema_dataset.json
+++ b/docs/schema/jsonschema_dataset.json
@@ -288,6 +288,6 @@
       "maxItems": 5
     }
   },
-  "required": [ "type", "dataset_id", "dataset_version", "name"]
+  "required": [ "type", "dataset_id", "dataset_version", "metadata_sources"]
 }
 

--- a/docs/schema/jsonschema_file.json
+++ b/docs/schema/jsonschema_file.json
@@ -63,6 +63,6 @@
       "uniqueItems": true
     }
   },
-  "required": [ "type", "dataset_id", "dataset_version", "path"]
+  "required": [ "type", "dataset_id", "dataset_version", "path", "metadata_sources"]
 }
 


### PR DESCRIPTION
- This removes the now-redundant code from this repo, and deduplicates code across repositories
- Equivalent of https://github.com/sfb1451/tabby-utils/pull/9
- Closes https://github.com/psychoinformatics-de/sfb1451-projects-catalog/issues/52
