### PR TITLE
Allow linked data definitions to be rendered intuitively in the `additional_display` tabs

### DIFF
--- a/docs/assets/app_component_dataset.js
+++ b/docs/assets/app_component_dataset.js
@@ -205,7 +205,9 @@ const datasetView = () =>
               disp_dataset.additional_tabs = dataset.additional_display
               disp_dataset.display_tabs = []
               disp_dataset.additional_tab_defs = dataset.additional_display_definitions
-              for (var t=0; t<disp_dataset.additional_tabs.length; t++) {
+              disp_dataset.additional_tab_count =
+                Array.isArray(disp_dataset.additional_tabs) ? disp_dataset.additional_tabs.length : 0
+              for (var t=0; t<disp_dataset.additional_tab_count; t++) {
                 n = disp_dataset.additional_tabs[t].name
               }
               disp_dataset.additional_tab_render = {}

--- a/docs/assets/app_component_dataset.js
+++ b/docs/assets/app_component_dataset.js
@@ -201,6 +201,14 @@ const datasetView = () =>
               else {
                 disp_dataset.show_export = false
               }
+              // Additional display and definitions
+              disp_dataset.additional_tabs = dataset.additional_display
+              disp_dataset.display_tabs = []
+              disp_dataset.additional_tab_defs = dataset.additional_display_definitions
+              for (var t=0; t<disp_dataset.additional_tabs.length; t++) {
+                n = disp_dataset.additional_tabs[t].name
+              }
+              disp_dataset.additional_tab_render = {}
               // Write main derived variable and set to ready
               this.displayData = disp_dataset;
               this.display_ready = true;
@@ -501,7 +509,7 @@ const datasetView = () =>
             }
           },
           setCorrectTab(tab_param) {
-            // the set of available tabs have been updated in component
+            // the set of available tabs has been updated in component
             // data in either created() or beforeRouteUpdate()
             var tabs = this.$root.selectedDataset.available_tabs.map(v => v.toLowerCase());
             // If no tab parameter is supplied via the router, set to first tab
@@ -518,7 +526,19 @@ const datasetView = () =>
                 this.tabIndex = 0;
               }
             }
-          }
+          },
+          getDefinitionURL(tab, key, nested_key = null, type = 'keys') {
+            if (nested_key != null) {
+              return this.displayData.additional_tab_defs[tab][type][key][nested_key]
+            } else {
+              var value = this.displayData.additional_tab_defs[tab][type][key]
+              if (typeof value === 'object') {
+                return type == 'keys' ? value.self : value
+              } else {
+                return value
+              }
+            }
+          },
         },
         async beforeRouteUpdate(to, from, next) {
           this.tabIndex = 0;

--- a/docs/assets/app_globals.js
+++ b/docs/assets/app_globals.js
@@ -95,3 +95,7 @@ async function checkFileExists(url) {
     return false;
   }
 }
+
+function toUpperString(str_in) {
+  return str_in.charAt(0).toUpperCase() + str_in.slice(1)
+}

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -250,3 +250,8 @@ li[class="item"]:last-child {
   padding-left: 5px;
   border-left: 2px solid #a9afb440;
 }
+
+.def-tooltip .tooltip-inner{
+  max-width: 500px !important;
+  width: 300px !important;
+}

--- a/docs/templates/dataset-template.html
+++ b/docs/templates/dataset-template.html
@@ -465,8 +465,8 @@
             </b-tab>
           </span>
           <!-- EXTRA TABS -->
-          <span v-if="selectedDataset.additional_display && selectedDataset.additional_display.length">
-            <span v-for="new_tab in selectedDataset.additional_display">
+          <span v-show="displayData.additional_tabs && displayData.additional_tabs.length">
+            <span v-for="new_tab in displayData.additional_tabs">
               <b-tab :key="new_tab.name" ref="tabelement">
                 <template v-slot:title>
                   <span v-if="new_tab.icon"><i :class="new_tab.icon"></i></span><span v-else><i class="fas fa-bars"></i></span> {{new_tab.name}}
@@ -480,7 +480,92 @@
                         <th>Value(s)</th>
                       </tr>
                     </thead>
-                    <tbody>
+                    <tbody v-if="displayData.additional_tab_defs">
+                      <!-- A row per key-value pair -->
+                      <tr v-for="content_key in Object.keys(new_tab.content)">
+                         <!-- PROPERTY NAME-->
+                         <td width="20%">
+                          <strong>
+                            <span :id="new_tab.name + '_' + content_key">{{ toUpperString(content_key) }}</span>
+                            <span v-if="getDefinitionURL(new_tab.name, content_key)">
+                              &nbsp;<sup><i :id="new_tab.name + '_' + content_key + '_info'" class="fas fa-circle-info"></i></sup>
+                              <b-tooltip custom-class="def-tooltip" :target="new_tab.name + '_' + content_key + '_info'" placement="topleft">
+                                <a :href="getDefinitionURL(new_tab.name, content_key)">{{ getDefinitionURL(new_tab.name, content_key) }}</a>
+                              </b-tooltip>
+                            </span>
+                          </strong>
+                         </td>
+                         <!-- PROPERTY VALUE -->
+                         <!-- Value: could be a string, array, or object, or not specified-->
+                         <!-- Value: an object would in turn have more key-value pairs-->
+                         <td>
+                          <!-- not specified -->
+                          <span v-if="!new_tab.content[content_key]"><em>not specified</em></span>
+                          <!-- array -->
+                          <span v-else-if="Array.isArray(new_tab.content[content_key])">
+                            <span v-for="(val, idx) in new_tab.content[content_key]">
+                              <span v-if="getDefinitionURL(new_tab.name, content_key, idx, 'values') == 'https://schema.org/email'">
+                                <a :href="'mailto:' + new_tab.content[content_key][idx]">{{new_tab.content[content_key][idx]}}</a>
+                              </span>
+                              <span v-else-if="getDefinitionURL(new_tab.name, content_key, idx, 'values') == 'https://schema.org/URL'">
+                                <a :href="new_tab.content[content_key][idx]" target="_blank">{{new_tab.content[content_key][idx]}}</a>
+                              </span>
+                              <span v-else-if="getDefinitionURL(new_tab.name, content_key, idx, 'values') == 'https://schema.org/Text'">
+                                {{new_tab.content[content_key][idx]}}
+                              </span>
+                              <span v-else>
+                                <a :href="getDefinitionURL(new_tab.name, content_key, idx, 'values')" target="_blank">{{new_tab.content[content_key][idx]}}</a>
+                              </span>
+                              <br>
+                            </span>
+                          </span>
+                          <!-- object -->
+                          <span v-else-if="typeof new_tab.content[content_key] === 'object'">
+                            <span v-for="k in Object.keys(new_tab.content[content_key])">
+                              <span><em>{{k}}</em>
+                                <span v-if="getDefinitionURL(new_tab.name, content_key, k)">
+                                  &nbsp;<sup><i :id="new_tab.name + '_' + content_key + '_' + k + '_info'" class="fas fa-circle-info"></i></sup>:
+                                  <b-tooltip custom-class="def-tooltip" :target="new_tab.name + '_' + content_key + '_' + k + '_info'" placement="topleft">
+                                    <a :href="getDefinitionURL(new_tab.name, content_key, k)" target="_blank">{{ getDefinitionURL(new_tab.name, content_key, k) }}</a>
+                                  </b-tooltip>
+                                </span>
+                              </span>
+                              <span>&nbsp;
+                                <span v-if="getDefinitionURL(new_tab.name, content_key, k, 'keys') == 'https://schema.org/email'">
+                                  <a :href="'mailto:' + new_tab.content[content_key][k]">{{new_tab.content[content_key][k]}}</a>
+                                </span>
+                                <span v-else-if="getDefinitionURL(new_tab.name, content_key, k, 'values') == 'https://schema.org/URL'">
+                                  <a :href="new_tab.content[content_key][k]">{{new_tab.content[content_key][k]}}</a>
+                                </span>
+                                <span v-else-if="getDefinitionURL(new_tab.name, content_key, k, 'values') == 'https://schema.org/Text'">
+                                  {{new_tab.content[content_key][k]}}
+                                </span>
+                                <span v-else>
+                                  <a :href="new_tab.content[content_key][k]">{{new_tab.content[content_key][k]}}</a>
+                                </span>
+                                <br>
+                              </span>
+                            </span>
+                          </span>
+                          <!-- string -->
+                          <span v-else>
+                            <span v-if="getDefinitionURL(new_tab.name, content_key, null, 'keys') == 'https://schema.org/email'">
+                              <a :href="'mailto:' + new_tab.content[content_key]">{{new_tab.content[content_key]}}</a>
+                            </span>
+                            <span v-else-if="getDefinitionURL(new_tab.name, content_key, null, 'values') == 'https://schema.org/URL'">
+                              <a :href="new_tab.content[content_key]" target="_blank">{{new_tab.content[content_key]}}</a>
+                            </span>
+                            <span v-else-if="getDefinitionURL(new_tab.name, content_key, null, 'values') == 'https://schema.org/Text'">
+                              {{new_tab.content[content_key]}}
+                            </span>
+                            <span v-else>
+                              <a :href="getDefinitionURL(new_tab.name, content_key, null, 'values')" target="_blank">{{new_tab.content[content_key]}}</a>
+                            </span>
+                          </span>
+                         </td>  
+                      </tr>
+                     </tbody>
+                     <tbody v-else>
                       <tr v-for="content_key in Object.keys(new_tab.content)">
                          <td><strong>{{ content_key.charAt(0).toUpperCase() + content_key.slice(1) }}</strong></td> 
                          <td>
@@ -494,7 +579,7 @@
                             </span>
                           </span>
                           <span v-else>{{ new_tab.content[content_key] }}</span>
-                         </td>
+                         </td>  
                       </tr>
                      </tbody>
                   </table>


### PR DESCRIPTION
This applies changes from [datalad-catalog 30773cb8797c39cf963f3a147cc51b9f79df0056](https://github.com/datalad/datalad-catalog/commit/30773cb8797c39cf963f3a147cc51b9f79df0056) which allows linked data definitions to be rendered intuitively in the additional display tabs.

It addresses https://github.com/psychoinformatics-de/sfb1451-projects-catalog/issues/41 in part, since it only applies to the `additional_display` tab for SFB1451, and not for fields rendered on the main dataset page or other tabs (content, subdatasets, etc).