### PR TITLE
Draft a Grant-funding card template

### DIFF
--- a/code/extract_project.py
+++ b/code/extract_project.py
@@ -77,7 +77,13 @@ handcrafted_item = get_metadata_item(
 project_name = args.dataset.name  # asume dataset.tld = project name
 if (keywords := manually_entered["keywords"].get(project_name)) is not None:
     handcrafted_item["keywords"] = keywords
-handcrafted_item["funding"] = manually_entered["funding"].get("sfb1451")
+
+sfb_grant = manually_entered["funding"]["sfb1451"]
+project_grant = manually_entered["funding"].get(project_name)
+
+handcrafted_item["funding"] = (
+    [sfb_grant, project_grant] if project_grant is not None else [sfb_grant]
+)
 
 with translated_path.open("a") as json_file:
     json.dump(handcrafted_item, json_file)

--- a/code/extract_superdataset.py
+++ b/code/extract_superdataset.py
@@ -45,8 +45,33 @@ with translated_path.open("w") as json_file:
     ):
         assert res["status"] == "ok"  # crude check
         metadata_item = postprocess(res)
+
+        # actually let's ignore all funding and add manually later
+        _ = metadata_item.pop("funding", None)
+
         json.dump(metadata_item, json_file)
         json_file.write("\n")
+
+
+# inject (make manual additions)
+with open(Path(__file__).parent / "manually_entered.toml", "rb") as f:
+    manually_entered = tomli.load(f)
+
+ds = Dataset(args.dataset)
+handcrafted_item = get_metadata_item(
+    item_type="dataset",
+    dataset_id=ds.id,
+    dataset_version=ds.repo.get_hexsha(),
+    source_name="manual_addition",
+    source_version="0.1.0",
+)
+handcrafted_item["license"] = manually_entered["license"]["superdataset"]
+handcrafted_item["funding"] = [manually_entered["funding"]["sfb1451"]]
+
+with translated_path.open("a") as json_file:
+    json.dump(handcrafted_item, json_file)
+    json_file.write("\n")
+
 
 # update catalog if requested
 if args.catalog is not None:

--- a/code/manually_entered.toml
+++ b/code/manually_entered.toml
@@ -322,7 +322,196 @@ Z02 = "Animal Motor Circuits Core Facility"
 Z03 = "Human Motor Assessment Centre"
 
 [funding]
-[[funding.sfb1451]]
-name = "Deutsche Forschungsgemeinschaft (DFG)"
-identifier = "Project number 431549029"
-description = "SFB1451: Key mechanisms of motor control in health and disease"
+
+[funding.sfb1451]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "SFB 1451: Key mechanisms of motor control in health and disease"
+identifier = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A01]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Understanding plastin 3 and its interactors in motor neuron function and plasticity in health and disease"
+alternateName = "A01"
+identifier = "https://gepris.dfg.de/gepris/projekt/458620544"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A02]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Dysregulation of the autophagy-endolysosomal system as a putative pathological mechanism behind the motor control dysfunction"
+alternateName = "A02"
+identifier = "https://gepris.dfg.de/gepris/projekt/458627899"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A03]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Motor learning-induced plasticity of cerebellar Purkinje neuron connectivity"
+alternateName = "A03"
+identifier = "https://gepris.dfg.de/gepris/projekt/458628816"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A04]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "The role of the reward system in obesity- and ageing-associated changes of motor behaviours"
+alternateName = "A04"
+identifier = "https://gepris.dfg.de/gepris/projekt/458630481"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A05]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Neural mechanisms underlying motor flexibility in fruit fly walking"
+alternateName = "A05"
+identifier = "https://gepris.dfg.de/gepris/projekt/458631052"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A06]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Sensory-motor pathways controlling voluntary movements in health and disease"
+alternateName = "A06"
+identifier = "https://gepris.dfg.de/gepris/projekt/458633663"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.A07]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Role of synaptic lipid modulated cortical excitability in motor control"
+alternateName = "A07"
+identifier = "https://gepris.dfg.de/gepris/projekt/470703892"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.B01]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Developmental mechanisms affecting motor skills and motor control"
+alternateName = "B01"
+identifier = "https://gepris.dfg.de/gepris/projekt/458636148"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.B02]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Neural network maturation underlying top-down motor control and movement initiation in childhood and adolescence"
+alternateName = "B02"
+identifier = "https://gepris.dfg.de/gepris/projekt/458637144"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.B03]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Modelling neural network dynamics underlying movements in health and disease"
+alternateName = "B03"
+identifier = "https://gepris.dfg.de/gepris/projekt/458638358"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.B04]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Motor control under uncertainty in the healthy human brain"
+alternateName = "B04"
+identifier = "https://gepris.dfg.de/gepris/projekt/458639706"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.B05]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Single-case predictions of motor abilities in health and disease"
+alternateName = "B05"
+identifier = "https://gepris.dfg.de/gepris/projekt/458640473"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.C01]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Identification and selective stimulation of motor recovery-related functional networks after experimental stroke"
+alternateName = "C01"
+identifier = "https://gepris.dfg.de/gepris/projekt/458642074"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.C03]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Striatal dopamine and volitional motor control: vigour, planning, and incentive salience "
+alternateName = "C03"
+identifier = "https://gepris.dfg.de/gepris/projekt/458646297"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.C04]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Apraxia in Alzheimer’s disease: Plastic reorganization of praxis networks in response to chronically progressive dysfunction"
+alternateName = "C04"
+identifier = "https://gepris.dfg.de/gepris/projekt/458674749"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.C05]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Reorganisation of the motor system following stroke"
+alternateName = "C05"
+identifier = "https://gepris.dfg.de/gepris/projekt/458684554"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.C06]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Major depression as a transient functional lesion model of motor control"
+alternateName = "C06"
+identifier = "https://gepris.dfg.de/gepris/projekt/458685554"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.C07]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Neural networks underlying motor tic formation and suppression"
+alternateName = "C07"
+identifier = "https://gepris.dfg.de/gepris/projekt/458687122"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.INF]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Data Managment"
+alternateName = "INF"
+identifier = "https://gepris.dfg.de/gepris/projekt/458705875"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.Z01]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Central Office"
+alternateName = "Z01"
+identifier = "https://gepris.dfg.de/gepris/projekt/458691909"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.Z02]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Animal Motor Core Facility"
+alternateName = "Z02"
+identifier = "https://gepris.dfg.de/gepris/projekt/458701226"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[funding.Z03]
+funder = "Deutsche Forschungsgemeinschaft (DFG)"
+name = "Humanes Motor-Assesment Center"
+alternateName = "Z03"
+identifier = "https://gepris.dfg.de/gepris/projekt/458705014"
+isPartOf = "https://gepris.dfg.de/gepris/projekt/431549029"
+"@type" = "https://schema.org/Grant"
+
+[license]
+[license.superdataset]
+name = "Individual, see datasets' terms"
+
+[additional]
+# B03 / externally-cued-movements
+[[additional.a808f9e1-d638-4771-ae4c-ff21da29151a.notebooks]]
+git_repo_url = "https://github.com/sfb1451/B03_externally-cued-movements"
+notebook_path = "code/example.ipynb"
+

--- a/docs/templates/dataset-template.html
+++ b/docs/templates/dataset-template.html
@@ -336,7 +336,7 @@
               <span v-if="!selectedDataset.funding || !selectedDataset.funding.length"><em>There are no funding sources listed for the current dataset</em></span>
               <span v-else v-for="fund in selectedDataset.funding">
 
-                <b-card v-if="fund?.['@type']=='schema:Grant'" border-variant="dark" header-bg-variant="transparent" no-body class="mb-2">
+                <b-card v-if="fund?.['@type']=='https://schema.org/Grant'" border-variant="dark" header-bg-variant="transparent" no-body class="mb-2">
                   <!-- funding is a schema:grant -->
                   <template v-slot:header>
                     <b-row no-gutters>

--- a/docs/templates/dataset-template.html
+++ b/docs/templates/dataset-template.html
@@ -335,7 +335,41 @@
               </template>
               <span v-if="!selectedDataset.funding || !selectedDataset.funding.length"><em>There are no funding sources listed for the current dataset</em></span>
               <span v-else v-for="fund in selectedDataset.funding">
-                <b-card border-variant="dark" header-bg-variant="transparent" no-body class="mb-2">
+
+                <b-card v-if="fund?.['@type']=='schema:Grant'" border-variant="dark" header-bg-variant="transparent" no-body class="mb-2">
+                  <!-- funding is a schema:grant -->
+                  <template v-slot:header>
+                    <b-row no-gutters>
+                      <b-col align-h="center" align-v="center" md="1">
+                        <span class="xxlfont"><i class="fas fa-dollar-sign "></i></span>
+                      </b-col>
+                      <b-col class="text-muted" md="11">
+                        <h5><span v-if="fund.funder">{{fund.funder}}</span><span v-else><em>(funder not specified)</em></span></h5>
+                        <span v-if="fund.name"><small><strong>Grant name:</strong> {{fund.name}}</small><br></span>
+
+                        <template v-if="fund.alternateName && fund?.identifier.startsWith('http')">
+                          <!-- if identifier is an url and alternateName is given, combobulate the two  -->
+                          <span><small><strong>Grant identifier: </strong><a :href="fund.identifier">{{fund.alternateName}}</a></small><br></span>
+                        </template>
+
+                        <template v-else>
+                          <!-- in other case, show available items individually; if identifier is a url, show it as link -->
+                          <span v-if="fund?.identifier.startsWith('http')">
+                            <small><strong>Grant identifier: </strong><a :href="fund.identifier">{{fund.identifier}}</a></small><br>
+                          </span>
+                          <span v-else-if="fund.identifier">
+                            <small><strong>Grant identifier: </strong> {{fund.identifier}}</small><br>
+                          </span>
+                          <span v-if="fund.alternateName"><small><strong>Alternate name: </strong> {{fund.alternateName}}</small><br></span>
+                        </template>
+
+                      </b-col>
+                    </b-row>
+                  </tempate>
+                </b-card>
+
+                <b-card v-else border-variant="dark" header-bg-variant="transparent" no-body class="mb-2">
+                  <!-- funding follows the catalog schema -->
                   <template v-slot:header>
                     <b-row no-gutters>
                       <b-col align-h="center" align-v="center" md="1">

--- a/docs/templates/dataset-template.html
+++ b/docs/templates/dataset-template.html
@@ -345,24 +345,20 @@
                       </b-col>
                       <b-col class="text-muted" md="11">
                         <h5><span v-if="fund.funder">{{fund.funder}}</span><span v-else><em>(funder not specified)</em></span></h5>
-                        <span v-if="fund.name"><small><strong>Grant name:</strong> {{fund.name}}</small><br></span>
-
-                        <template v-if="fund.alternateName && fund?.identifier.startsWith('http')">
-                          <!-- if identifier is an url and alternateName is given, combobulate the two  -->
-                          <span><small><strong>Grant identifier: </strong><a :href="fund.identifier">{{fund.alternateName}}</a></small><br></span>
+                        <span v-if="fund.name">
+                          <small><strong>Grant name:</strong> {{fund.name}}</small><br>
+                        </span>
+                        <template v-if="fund.alternateName">
+                          <span><small><strong>Alternate name: </strong>{{fund.alternateName}}</small></span><br>
                         </template>
-
-                        <template v-else>
-                          <!-- in other case, show available items individually; if identifier is a url, show it as link -->
-                          <span v-if="fund?.identifier.startsWith('http')">
-                            <small><strong>Grant identifier: </strong><a :href="fund.identifier">{{fund.identifier}}</a></small><br>
-                          </span>
-                          <span v-else-if="fund.identifier">
-                            <small><strong>Grant identifier: </strong> {{fund.identifier}}</small><br>
-                          </span>
-                          <span v-if="fund.alternateName"><small><strong>Alternate name: </strong> {{fund.alternateName}}</small><br></span>
-                        </template>
-
+                        <span v-if="fund.identifier">
+                          <template v-if="fund.identifier.startsWith('http')">
+                            <small><strong>Grant identifier:</strong> <a :href="fund.identifier">{{fund.identifier}}</a></small><br>
+                          </template>
+                          <template v-else>
+                            <small><strong>Grant identifier:</strong> {{fund.identifier}}</small><br>
+                          </template>
+                        </span>
                       </b-col>
                     </b-row>
                   </tempate>

--- a/docs/templates/dataset-template.html
+++ b/docs/templates/dataset-template.html
@@ -351,6 +351,9 @@
                         <template v-if="fund.alternateName">
                           <span><small><strong>Alternate name: </strong>{{fund.alternateName}}</small></span><br>
                         </template>
+                        <span v-if="fund.description">
+                          <small><strong>Description:</strong> {{fund.description}}</small><br>
+                        </span>
                         <span v-if="fund.identifier">
                           <template v-if="fund.identifier.startsWith('http')">
                             <small><strong>Grant identifier:</strong> <a :href="fund.identifier">{{fund.identifier}}</a></small><br>
@@ -358,6 +361,12 @@
                           <template v-else>
                             <small><strong>Grant identifier:</strong> {{fund.identifier}}</small><br>
                           </template>
+                        </span>
+                        <span v-if="fund.url">
+                          <small><strong>URL:</strong> <a :href="fund.url">{{fund.url}}</a></small><br>
+                        </span>
+                        <span v-if="fund.sameAs">
+                          <small><strong>Same as:</strong> <a :href="fund.sameAs">{{fund.sameAs}}</a></small><br>
                         </span>
                       </b-col>
                     </b-row>


### PR DESCRIPTION
Addressing #67, this expands the dataset template with a custom "card" that will be used to display funding items that are annotated with `@type = https://schema.org/Grant`:

![image](https://github.com/psychoinformatics-de/sfb1451-projects-catalog/assets/11985212/110c8559-efdb-408b-aaa0-8708f397f1c3)

Items without this `@type` will be displayed according to the catalog schema, as previously.

The custom card relies on (some) field names defined in https://schema.org/Grant. Although there is a mismatch with the catalog schema, there are no validation issues, as the catalog schema does not mark any funding item property as required (and does not error on additional fields).

Not all fields need to be used. In fact, we will most likely use the following to display SFB project acknowledgement as two grant cards (one for SFB and one for project):

![Screenshot from 2024-02-21 12-29-55](https://github.com/psychoinformatics-de/sfb1451-projects-catalog/assets/11985212/450fdaa2-7c98-4f53-9235-b5ec0839f6a0)

A companion PR (to produce such items) is https://github.com/sfb1451/tabby-utils/pull/16

Having the tabby metadata displayed in the new way would require re-adding all tabby metadata (`datalad foreach-dataset` can be used for the purpose).