### PR TITLE
Display subdataset titles instead of their directory names

### DIFF
--- a/docs/assets/app_component_dataset.js
+++ b/docs/assets/app_component_dataset.js
@@ -57,6 +57,9 @@ const datasetView = () =>
                       subds.keywords.filter((item) => tags.indexOf(item) < 0)
                     );
                   }
+                  if (subds.available) {
+                      subds.display_name = subds.name ? subds.name : subds.dirs_from_path.at(-1);
+                  }
                 });
               }           
               this.tag_options = tags;
@@ -319,9 +322,9 @@ const datasetView = () =>
             return all_subdatasets.filter((c) => {
               if (this.search_text == "") return true;
               return (
-                c.dirs_from_path[c.dirs_from_path.length - 1]
+                c.display_name
                   .toLowerCase()
-                  .indexOf(this.search_text.toLowerCase()) >= 0 ||
+                  .includes(this.search_text.toLowerCase()) ||
                 c.authors.some(
                   (f) =>
                   f.givenName && f.givenName.toLowerCase().indexOf(this.search_text.toLowerCase()) >= 0 
@@ -348,19 +351,9 @@ const datasetView = () =>
             subdatasets = this.tagFilteredSubdatasets;
             if (this.sort_name_or_modified) {
               if (this.sort_name) {
-                sorted = subdatasets.sort((a, b) =>
-                  a.dirs_from_path[a.dirs_from_path.length - 1] >
-                  b.dirs_from_path[b.dirs_from_path.length - 1]
-                    ? 1
-                    : -1
-                );
+                  sorted = subdatasets.sort((a, b) => a.display_name.localeCompare(b.display_name));
               } else {
-                sorted = subdatasets.sort((a, b) =>
-                  a.dirs_from_path[a.dirs_from_path.length - 1] <
-                  b.dirs_from_path[b.dirs_from_path.length - 1]
-                    ? 1
-                    : -1
-                );
+                  sorted = subdatasets.sort((a, b) => b.display_name.localeCompare(a.display_name));
               }
             } else {
               if (this.sort_modified) {

--- a/docs/templates/dataset-template.html
+++ b/docs/templates/dataset-template.html
@@ -325,7 +325,7 @@
                         <span class="xxlfont"><i class="fas fa-database"></i></span>
                       </b-col>
                       <b-col class="text-muted" md="7">
-                        <h5><a :href="'/dataset/'+ds.dataset_id+'/'+ds.dataset_version" @click.prevent="selectDataset($event, ds)" class="newlink">{{ds.dirs_from_path.at(-1)}}</a></h5>
+                        <h5><a :href="'/dataset/'+ds.dataset_id+'/'+ds.dataset_version" @click.prevent="selectDataset($event, ds)" class="newlink">{{ds.display_name}}</a></h5>
                         <span v-for="(author, index) in ds.authors">
                           <small>
                             <span v-if="author.givenName">{{author.givenName}} {{author.familyName}}</span><span v-else>{{author.name}}</span><span v-if="index != ds.authors.length - 1">, </span>
@@ -335,6 +335,7 @@
                           <small>
                             <strong>Version:</strong> {{ds.dataset_version.substring(0,7)}}&nbsp;
                             <strong>Modified:</strong> {{getDateFromUTCseconds(ds.source_time)}}&nbsp;
+                            <strong>Directory:</strong> {{ds.dirs_from_path.at(-1)}}&nbsp;
                           </small>
                         </b-card-text>
                       </b-col>


### PR DESCRIPTION
The subdataset card is modified so that the subdataset title is shown as the card header (the big text linking to the subdataset page), replacing directory name. Sorting is adjusted accordingly, and made case-insensitive.

The directory name is used as the card header if the title is not available, and always shown in small text as "directory".

To achieve this, subdatasets_ready() function is modified to add a display_name property to each subdataset object (similar to what dataset_ready does to the superdataset). The property is needed twice: for sorting (js code) and for display (html template), so it seemed appropriate to add the property instead of having to use the ternary operator twice.

Subdataset sorting uses localeCompare() on the names, which seems to be the recommended method to achieve case-insensitive comparison: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare

The fact that we only define the name for available datasets does not seem to be a problem, as the sortedSubdatasets() is called only after filteredSubdatasets() which filters by the available property.

Closes #96

Example:
![image](https://github.com/sfb1451/metadata-catalog/assets/11985212/8413c03b-c28b-4000-adc5-c5258732c58d)
